### PR TITLE
SONARUNNER-154 OkHttpClient doesn't use ssl socket factory by default

### DIFF
--- a/api/src/main/java/org/sonarsource/scanner/impl/OkHttpClientFactory.java
+++ b/api/src/main/java/org/sonarsource/scanner/impl/OkHttpClientFactory.java
@@ -49,6 +49,20 @@ public class OkHttpClientFactory {
       .supportsTlsExtensions(true)
       .build();
     httpClient.setConnectionSpecs(asList(tls, ConnectionSpec.CLEARTEXT));
+    httpClient.setSslSocketFactory(createSslSocketFactory(javaVersion));
+    return httpClient;
+  }
+
+  private static SSLSocketFactory createSslSocketFactory(JavaVersion javaVersion) {
+    try {
+      SSLSocketFactory sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+      return enableTls12InJava7(sslSocketFactory, javaVersion);
+    } catch (Exception e) {
+      throw new IllegalStateException("Fail to init TLS context", e);
+    }
+  }
+
+  private static SSLSocketFactory enableTls12InJava7(SSLSocketFactory sslSocketFactory, JavaVersion javaVersion) {
     if (javaVersion.isJava7()) {
       // OkHttp executes SSLContext.getInstance("TLS") by default (see
       // https://github.com/square/okhttp/blob/c358656/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java#L616)
@@ -56,13 +70,9 @@ public class OkHttpClientFactory {
       // in order to support all versions from 1.0 to 1.2.
       // Note that this is not overridden for Java 8 as TLS 1.2 is enabled by default.
       // Keeping getInstance("TLS") allows to support potential future versions of TLS on Java 8.
-      try {
-        httpClient.setSslSocketFactory(new Tls12Java7SocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault()));
-      } catch (Exception e) {
-        throw new IllegalStateException("Fail to init TLS context", e);
-      }
+      return new Tls12Java7SocketFactory(sslSocketFactory);
     }
-    return httpClient;
+    return sslSocketFactory;
   }
 
   static class JavaVersion {

--- a/api/src/main/java/org/sonarsource/scanner/impl/ServerConnection.java
+++ b/api/src/main/java/org/sonarsource/scanner/impl/ServerConnection.java
@@ -28,7 +28,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Properties;
-import javax.net.ssl.SSLSocketFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.sonarsource.scanner.cache.Logger;
@@ -50,7 +49,6 @@ class ServerConnection {
     this.baseUrlWithoutTrailingSlash = removeTrailingSlash(baseUrl);
     this.userAgent = userAgent;
     this.httpClient = OkHttpClientFactory.create();
-    this.httpClient.setSslSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
   }
 
   private static String removeTrailingSlash(String url) {

--- a/api/src/test/java/org/sonarsource/scanner/impl/OkHttpClientFactoryTest.java
+++ b/api/src/test/java/org/sonarsource/scanner/impl/OkHttpClientFactoryTest.java
@@ -22,6 +22,7 @@ package org.sonarsource.scanner.impl;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.OkHttpClient;
 import java.util.List;
+import javax.net.ssl.SSLSocketFactory;
 import org.junit.Test;
 import org.sonarsource.scanner.impl.OkHttpClientFactory;
 
@@ -49,8 +50,7 @@ public class OkHttpClientFactoryTest {
     OkHttpClient underTest = OkHttpClientFactory.create(javaVersion);
 
     assertTlsAndClearTextSpecifications(underTest);
-    // do not override the default TLS context provided by java 8
-    assertThat(underTest.getSslSocketFactory()).isNull();
+    assertThat(underTest.getSslSocketFactory()).isInstanceOf(SSLSocketFactory.getDefault().getClass());
   }
 
   private void assertTlsAndClearTextSpecifications(OkHttpClient client) {


### PR DESCRIPTION
since we didn't set it for Java 8, SSL connections opened with OkHttpClient under Java 8 didn't have any of the SSL parameters