### PR TITLE
check correctly size of array before reading array element

### DIFF
--- a/api/src/main/java/org/sonarsource/scanner/api/internal/Jars.java
+++ b/api/src/main/java/org/sonarsource/scanner/api/internal/Jars.java
@@ -84,7 +84,7 @@ class Jars {
         if (!"".equals(line)) {
           String[] libAndHash = line.split("\\|");
           String filename = libAndHash[0];
-          String hash = libAndHash.length > 0 ? libAndHash[1] : "";
+          String hash = libAndHash.length > 1 ? libAndHash[1] : "";
           files.add(fileCache.get(filename, hash, batchFileDownloader));
         }
       }


### PR DESCRIPTION
My problem is that I'm using gradle with sonarqube plugin 2.2.1 and sonarqube server 6.1

The task fails with the following error:

org.sonarsource.scanner.api.internal.JarDownloader.download(JarDownloader.java:39)
09:26:39.782 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] 	at org.sonarsource.scanner.api.internal.IsolatedLauncherFactory$1.run(IsolatedLauncherFactory.java:75)
09:26:39.782 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] 	... 83 more
09:26:39.782 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] Caused by: java.lang.ArrayIndexOutOfBoundsException: 1
09:26:39.783 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] 	at org.sonarsource.scanner.api.internal.Jars.downloadFiles(Jars.java:87)

The request

Download: http://xxxxx/batch_bootstrap/index

returns (in the machine where the job runs)

root@ptlisvlsdn020:/root # curl http://xxxxxx/batch/index
sonar-scanner-engine-shaded-6.1.jar|4547fad89fb93ac4f0eb15e446e2e0c2
root@ptlisvlsdn020:/root #

I don't understand why the parsing fails to give 2 elements in the array but the check is wrong.