### PR TITLE
SCANNERAPI-180 sonarcloud.io a default host for BitbucketCloud

### DIFF
--- a/api/src/main/java/org/sonarsource/scanner/api/System2.java
+++ b/api/src/main/java/org/sonarsource/scanner/api/System2.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Scanner API
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.scanner.api;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * A proxy class for java.lang.System (for mocking).
+ */
+public class System2 {
+  @CheckForNull
+  public String getEnvironmentVariable(@Nonnull String key) {
+    return System.getenv(key);
+  }
+}


### PR DESCRIPTION
Make sonarcloud.io the default host when scanner is executed from BitbucketCloud pipeline.