### PR TITLE
make connect timeout configurable

### DIFF
--- a/api/src/main/java/org/sonarsource/scanner/api/internal/OkHttpClientFactory.java
+++ b/api/src/main/java/org/sonarsource/scanner/api/internal/OkHttpClientFactory.java
@@ -48,7 +48,8 @@ import static java.util.Arrays.asList;
 public class OkHttpClientFactory {
 
   static final String READ_TIMEOUT_SEC_PROPERTY = "sonar.ws.timeout";
-  static final int CONNECT_TIMEOUT_MILLISECONDS = 5_000;
+  static final String CONNECT_TIMEOUT_SEC_PROPERTY = "sonar.connect.timeout";
+  static final int DEFAULT_CONNECT_TIMEOUT_SEC = 5;
   static final int DEFAULT_READ_TIMEOUT_SEC = (int) Duration.ofMinutes(5).getSeconds();
   static final String NONE = "NONE";
   static final String P11KEYSTORE = "PKCS11";
@@ -66,7 +67,12 @@ public class OkHttpClientFactory {
       readTimeoutSec = Integer.parseInt(System.getProperty(READ_TIMEOUT_SEC_PROPERTY));
     }
 
-    okHttpClientBuilder.connectTimeout(CONNECT_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
+    int connectTimeoutSec = DEFAULT_CONNECT_TIMEOUT_SEC;
+    if (!System.getProperty(CONNECT_TIMEOUT_SEC_PROPERTY, "").isEmpty()) {
+      connectTimeoutSec = Integer.parseInt(System.getProperty(CONNECT_TIMEOUT_SEC_PROPERTY));
+    }
+
+    okHttpClientBuilder.connectTimeout(connectTimeoutSec, TimeUnit.SECONDS);
     okHttpClientBuilder.readTimeout(readTimeoutSec, TimeUnit.SECONDS);
 
     ConnectionSpec tls = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)

--- a/api/src/test/java/org/sonarsource/scanner/api/internal/OkHttpClientFactoryTest.java
+++ b/api/src/test/java/org/sonarsource/scanner/api/internal/OkHttpClientFactoryTest.java
@@ -68,6 +68,7 @@ public class OkHttpClientFactoryTest {
   private static final String KEYSTORE_FILE = "/server.jks";
   private static final Logger logger = mock(Logger.class);
   private static final String SONAR_WS_TIMEOUT = "sonar.ws.timeout";
+  private static final String SONAR_CONNECT_TIMEOUT = "sonar.connect.timeout";
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -75,6 +76,7 @@ public class OkHttpClientFactoryTest {
   @After
   public void cleanSystemProperty() {
     System.clearProperty(SONAR_WS_TIMEOUT);
+    System.clearProperty(SONAR_CONNECT_TIMEOUT);
   }
 
   @Test
@@ -86,7 +88,7 @@ public class OkHttpClientFactoryTest {
   }
 
   @Test
-  public void support_custom_timeouts() {
+  public void support_custom_read_timeouts() {
     int readTimeoutSec = 2000;
     System.setProperty(SONAR_WS_TIMEOUT, String.valueOf(readTimeoutSec));
 
@@ -97,8 +99,27 @@ public class OkHttpClientFactoryTest {
   }
 
   @Test
-  public void support_custom_timeouts_throws_exception_on_non_number() {
+  public void support_custom_read_timeouts_throws_exception_on_non_number() {
     System.setProperty(SONAR_WS_TIMEOUT, "fail");
+
+    Logger logger = mock(Logger.class);
+    assertThatThrownBy(() -> OkHttpClientFactory.create(logger)).isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  public void support_custom_connect_timeouts() {
+    int connectTimeoutSec = 2000;
+    System.setProperty(SONAR_CONNECT_TIMEOUT, String.valueOf(connectTimeoutSec));
+
+    Logger logger = mock(Logger.class);
+    OkHttpClient underTest = OkHttpClientFactory.create(logger);
+
+    assertThat(underTest.connectTimeoutMillis()).isEqualTo(connectTimeoutSec * 1000);
+  }
+
+  @Test
+  public void support_custom_connect_timeouts_throws_exception_on_non_number() {
+    System.setProperty(SONAR_CONNECT_TIMEOUT, "fail");
 
     Logger logger = mock(Logger.class);
     assertThatThrownBy(() -> OkHttpClientFactory.create(logger)).isInstanceOf(NumberFormatException.class);


### PR DESCRIPTION
On some environments the default connect timeout of 5 seconds is not sufficient. In our environment the SonarQube sonar goes asleep after some time of inactivity. On next request it is spinned up again. This, however, usually takes longer than 5 seconds, resulting in a failed build.

Analogous to https://github.com/SonarSource/sonar-scanner-api/pull/60/files, I made the connect timeout configurable through a SystemProperty
