### PR TITLE
The HTTP client will honor Set-Cookie headers on response

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,6 +16,10 @@
       <artifactId>okhttp</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-urlconnection</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.eclipsesource.minimal-json</groupId>
       <artifactId>minimal-json</artifactId>
     </dependency>

--- a/api/src/main/java/org/sonarsource/scanner/api/internal/OkHttpClientFactory.java
+++ b/api/src/main/java/org/sonarsource/scanner/api/internal/OkHttpClientFactory.java
@@ -21,6 +21,8 @@ package org.sonarsource.scanner.api.internal;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
 import java.net.HttpURLConnection;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -41,6 +43,7 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
+import okhttp3.JavaNetCookieJar;
 import org.sonarsource.scanner.api.internal.cache.Logger;
 
 import static java.util.Arrays.asList;
@@ -52,10 +55,18 @@ public class OkHttpClientFactory {
   static final int DEFAULT_READ_TIMEOUT_SEC = (int) Duration.ofMinutes(5).getSeconds();
   static final String NONE = "NONE";
   static final String P11KEYSTORE = "PKCS11";
+  static final CookieManager COOKIE_MANAGER;
   private static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
+  private static final JavaNetCookieJar COOKIE_JAR;  // use the same cookie jar for all instances
 
   private OkHttpClientFactory() {
     // only statics
+  }
+
+  static {
+    COOKIE_MANAGER = new CookieManager();
+    COOKIE_MANAGER.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+    COOKIE_JAR = new JavaNetCookieJar(COOKIE_MANAGER);
   }
 
   static OkHttpClient create(Logger logger) {
@@ -68,6 +79,7 @@ public class OkHttpClientFactory {
 
     okHttpClientBuilder.connectTimeout(CONNECT_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
     okHttpClientBuilder.readTimeout(readTimeoutSec, TimeUnit.SECONDS);
+    okHttpClientBuilder.cookieJar(COOKIE_JAR);
 
     ConnectionSpec tls = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
       .allEnabledTlsVersions()

--- a/api/src/test/java/org/sonarsource/scanner/api/internal/OkHttpClientFactoryTest.java
+++ b/api/src/test/java/org/sonarsource/scanner/api/internal/OkHttpClientFactoryTest.java
@@ -68,6 +68,7 @@ public class OkHttpClientFactoryTest {
   private static final String KEYSTORE_FILE = "/server.jks";
   private static final Logger logger = mock(Logger.class);
   private static final String SONAR_WS_TIMEOUT = "sonar.ws.timeout";
+  private static final String COOKIE = "BIGipServerpool_sonarqube.example.com_8443=123456789.12345.0000";
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -175,6 +176,33 @@ public class OkHttpClientFactoryTest {
     }
   }
 
+  @Theory
+  public void test_with_cookie(String clientKeyStore) throws Exception {
+    try (MockWebServer server = buildTLSServer()) {
+      String url = format("https://localhost:%d/", server.getPort());
+
+      // Add the truststore
+      Path clientTruststore = Paths.get(getClass().getResource(clientKeyStore).toURI()).toAbsolutePath();
+      System.setProperty("javax.net.ssl.trustStore", clientTruststore.toString());
+      System.setProperty("javax.net.ssl.trustStorePassword", KEYSTORE_PASSWORD);
+
+      OkHttpClientFactory.COOKIE_MANAGER.getCookieStore().removeAll();  // Clear any existing cookies
+
+      Response response = call(url);
+     assertThat(response.header("Set-Cookie")).isEqualTo(COOKIE);  // The server should have asked us to set a cookie
+     assertThat(response.body().string()).doesNotContain(COOKIE);
+
+      response = call(url);
+      assertThat(response.body().string()).contains(COOKIE);
+
+    } finally {
+      // Ensure to not keeping this property for other tests
+      System.clearProperty("javax.net.ssl.trustStore");
+      System.clearProperty("javax.net.ssl.trustStorePassword");
+    }
+  }
+
+
   private static Response call(String url) throws IOException {
     return OkHttpClientFactory.create(logger).newCall(
       new Request.Builder()
@@ -193,7 +221,18 @@ public class OkHttpClientFactoryTest {
     server.setDispatcher(new Dispatcher() {
       @Override
       public MockResponse dispatch(RecordedRequest request) {
-        return new MockResponse().setResponseCode(200).setBody("OK");
+        String responseBody = "OK";
+        MockResponse response = new MockResponse().setResponseCode(200);
+        String cookie = request.getHeader("Cookie");
+        if (cookie == null || cookie.isEmpty()) {
+          // Only set the cookie if it is not already set
+          response.addHeader("Set-Cookie", COOKIE);
+        } else {
+          // dump the cookie into the response body to aid in test inspection
+          responseBody += "\nCookie: " + cookie;
+        }
+        response.setBody(responseBody);
+        return response;
       }
     });
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
         <version>${okhttp.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp-urlconnection</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.eclipsesource.minimal-json</groupId>
         <artifactId>minimal-json</artifactId>
         <version>0.9.5</version>


### PR DESCRIPTION
We have Sonar servers behind an F5 load balancer to provide HA (High Availability).

The load balancer sets a cookie so that requests from HTTP clients "stick" to a given concrete server.

sonar-scanner-api does not currently honor cookies and therefore does not get load balanced.
This is generally not a big deal - we noticed it when one of our concrete servers was corrupted.

The specific case we were interested in was the JAR download which involves two separate, consecutive API calls:

1. https://sonarqube.example.com/batch/index
1. https://sonarqube.example.com/batch/file?name=sonar-scanner-engine-shaded-6.7.jar

These are part of the same logical operation (downloading the JAR) and it really makes sense to honor the load balancer cookie at least for that.

