### PR TITLE
Use latest orchestrator version in tests.

### DIFF
--- a/its/it-tests/pom.xml
+++ b/its/it-tests/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.22.0.1791</version>
+      <version>3.30.0.2599</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
The old orchestrator defaults to an unresolvable hostname. This is fixed in the latest version.