### PR TITLE
Increase socket connect timeout to 30s

### DIFF
--- a/api/src/main/java/org/sonarsource/scanner/api/internal/OkHttpClientFactory.java
+++ b/api/src/main/java/org/sonarsource/scanner/api/internal/OkHttpClientFactory.java
@@ -51,7 +51,7 @@ import static java.util.Arrays.asList;
 public class OkHttpClientFactory {
 
   static final String READ_TIMEOUT_SEC_PROPERTY = "sonar.ws.timeout";
-  static final int CONNECT_TIMEOUT_MILLISECONDS = 5_000;
+  static final int CONNECT_TIMEOUT_MILLISECONDS = 30_000;
   static final int DEFAULT_READ_TIMEOUT_SEC = (int) Duration.ofMinutes(5).getSeconds();
   static final String NONE = "NONE";
   static final String P11KEYSTORE = "PKCS11";


### PR DESCRIPTION
According to this comment https://github.com/SonarSource/sonar-scanner-api/pull/62#issuecomment-817579733 this timeout should be increased to make it consistent with scanner engine. 

Current 5s timeout is not sufficient in some cases and our builds fail with a timeout exception:
```
Unable to execute SonarQube: Fail to get bootstrap index from server: connect timed out
```
