### PR TITLE
Handle empty response from /batch/index gracefully

### DIFF
--- a/api/src/main/java/org/sonarsource/scanner/api/internal/BootstrapIndexDownloader.java
+++ b/api/src/main/java/org/sonarsource/scanner/api/internal/BootstrapIndexDownloader.java
@@ -44,8 +44,8 @@ class BootstrapIndexDownloader {
     return parse(index);
   }
 
-  private static Collection<JarEntry> parse(String index) {
-    Collection<JarEntry> entries = new ArrayList<>();
+  private Collection<JarEntry> parse(String index) {
+    final Collection<JarEntry> entries = new ArrayList<>();
 
     String[] lines = index.split("[\r\n]+");
     for (String line : lines) {
@@ -56,6 +56,7 @@ class BootstrapIndexDownloader {
         String hash = libAndHash[1];
         entries.add(new JarEntry(filename, hash));
       } catch (Exception e) {
+        logger.error("Failed bootstrap index response: " + index);
         throw new IllegalStateException("Fail to parse entry in bootstrap index: " + line);
       }
     }

--- a/api/src/test/java/org/sonarsource/scanner/api/internal/BootstrapIndexDownloaderTest.java
+++ b/api/src/test/java/org/sonarsource/scanner/api/internal/BootstrapIndexDownloaderTest.java
@@ -73,6 +73,22 @@ public class BootstrapIndexDownloaderTest {
   }
 
   @Test
+  public void test_handles_empty_line_gracefully() throws Exception {
+    when(connection.downloadString("/batch/index")).thenReturn("\n");
+
+    Collection<JarEntry> index = bootstrapIndexDownloader.getIndex();
+    assertThat(index).hasSize(0);
+    verify(connection, times(1)).downloadString("/batch/index");
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void test_handles_empty_string_with_exception() throws Exception {
+    when(connection.downloadString("/batch/index")).thenReturn("");
+
+    bootstrapIndexDownloader.getIndex();
+  }
+
+  @Test
   public void should_fail() throws IOException {
     when(connection.downloadString("/batch/index")).thenThrow(new IOException("io error"));
 


### PR DESCRIPTION
Sonarqube 8.9 returns an empty string as response from /batch/index which can be handled gracefully rather than cause an 'java.lang.IllegalStateException: Fail to parse entry in bootstrap index: '.