### PR TITLE
Prepare for patch release

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.scanner.api</groupId>
     <artifactId>sonar-scanner-api-parent</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>2.16.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-scanner-api</artifactId>

--- a/batch-interface/pom.xml
+++ b/batch-interface/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.scanner.api</groupId>
     <artifactId>sonar-scanner-api-parent</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>2.16.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-scanner-api-batch-interface</artifactId>

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.scanner.api</groupId>
     <artifactId>sonar-scanner-api-parent</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>2.16.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-scanner-api-batch</artifactId>

--- a/its/it-simple-scanner/pom.xml
+++ b/its/it-simple-scanner/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.scanner.api</groupId>
     <artifactId>it</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>2.16.3-SNAPSHOT</version>
   </parent>
   
   <artifactId>it-scanner-api-simple-scanner</artifactId>

--- a/its/it-tests/pom.xml
+++ b/its/it-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonarsource.scanner.api</groupId>
     <artifactId>it</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>2.16.3-SNAPSHOT</version>
   </parent>
   
   <artifactId>it-sonar-scanner-api</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.scanner.api</groupId>
     <artifactId>sonar-scanner-api-parent</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>2.16.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>it</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.sonarsource.scanner.api</groupId>
   <artifactId>sonar-scanner-api-parent</artifactId>
-  <version>2.17-SNAPSHOT</version>
+  <version>2.16.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SonarQube Scanner API - Parent</name>
   <description>API used by all SonarQube Scanners (Maven, Gradle, Ant, CLI)</description>


### PR DESCRIPTION
I will release API first, as in scanner-cli it has been wrongly pointed out 2.17 which is not released.

Given the current changes I will just do a patch release of this artifact, and then bump it in scanner-cli.